### PR TITLE
Retrieve Deno repo std version, not local

### DIFF
--- a/update.ts
+++ b/update.ts
@@ -3,7 +3,7 @@ import {
   writeJson,
 } from "https://deno.land/std@0.61.0/fs/mod.ts";
 
-import { VERSION } from "./version.ts";
+import { VERSION } from "https://raw.githubusercontent.com/denoland/deno/std/0.61.0/std/version.ts";
 
 const nestAPI = "https://x.nest.land/api/package/std";
 

--- a/update.ts
+++ b/update.ts
@@ -3,7 +3,7 @@ import {
   writeJson,
 } from "https://deno.land/std@0.61.0/fs/mod.ts";
 
-import { VERSION } from "https://raw.githubusercontent.com/denoland/deno/std/0.61.0/std/version.ts";
+import { VERSION } from "https://denopkg.com/denoland/deno/std/version.ts";
 
 const nestAPI = "https://x.nest.land/api/package/std";
 


### PR DESCRIPTION
It appears that after adding the `NESTAPIKEY`, the CI fails because it is trying to retrieve the `version.ts` file from our repository and compare it to what exists on x. I don't think this is the intended action, so I replaced the url to point to Deno's official repository instead. 

This is the error that is displayed in the CI:
```
Successfully updated ~/.nest-api-key with your key!
Download https://denopkg.com/nestdotland/std/update.ts
Download https://raw.githubusercontent.com/nestdotland/std/master/update.ts
Download https://deno.land/std@0.61.0/fs/mod.ts
Download https://raw.githubusercontent.com/nestdotland/std/master/version.ts
error: Import 'https://raw.githubusercontent.com/nestdotland/std/master/version.ts' failed: 404 Not Found
Imported from "https://raw.githubusercontent.com/nestdotland/std/master/update.ts:6"
##[error]Process completed with exit code 1.
```

Let me know if this is wrong!